### PR TITLE
Actor weight perturbation functionality

### DIFF
--- a/src/reflect/components/rssm_world_model/memory_actor.py
+++ b/src/reflect/components/rssm_world_model/memory_actor.py
@@ -2,6 +2,7 @@ from reflect.components.models.actor import Actor
 from reflect.components.rssm_world_model.world_model import WorldModel
 from reflect.utils import FreezeParameters
 import torch
+import copy
 
 
 class WorldModelActor:
@@ -12,7 +13,17 @@ class WorldModelActor:
         ):
         self.world_model = world_model
         self.actor = actor
-    
+        self.actor_copy = copy.deepcopy(actor)
+
+    def perturb_actor(self, weight_perturbation_size: float = 0.01):
+        self.reset_to_original_actor()
+        for param_name, param in self.actor_copy.named_parameters():
+            if "weight" in param_name:
+                param.data = param.data + torch.randn_like(param.data) * weight_perturbation_size
+
+    def reset_to_original_actor(self):
+        self.actor_copy = copy.deepcopy(self.actor)
+
     def reset(self):
         self.state = self.world_model.dynamic_model.initial_state(1)
         self.action = torch.zeros(1, self.actor.output_dim)
@@ -38,7 +49,7 @@ class WorldModelActor:
         #################################
         device = next(self.actor.parameters()).device
         obs = obs.to(device)
-        with FreezeParameters([self.world_model, self.actor]):    
+        with FreezeParameters([self.world_model, self.actor, self.actor_copy]):
             embed_obs = self.world_model.encoder(obs)
             next_state = self.world_model.dynamic_model.posterior(embed_obs[:, 0], self.state)
             self.action = self.actor(next_state.get_features(), deterministic=True)

--- a/src/reflect/data/loader.py
+++ b/src/reflect/data/loader.py
@@ -148,7 +148,6 @@ class EnvDataLoader:
             self.noise_generator = NoNoise(dim=self.action_dim)
 
     def step(self, action):
-        print(action.shape)
         state, reward, done, *_ \
             = self.env.step(action.cpu().numpy())
         if self.use_imgs_as_states:

--- a/src/reflect/data/tests/test_data_loader.py
+++ b/src/reflect/data/tests/test_data_loader.py
@@ -1,5 +1,8 @@
 from reflect.data.loader import EnvDataLoader
-from torchvision.transforms import Resize, Compose
+from reflect.components.transformer_world_model.world_model_actor import EncoderActor
+from reflect.components.models import ConvEncoder
+from reflect.components.models import Actor
+
 import gymnasium as gym
 import torch
 import pytest
@@ -62,6 +65,64 @@ def test_data_loader_states(env_name):
     s, a, r, d = data_loader.sample(batch_size=3, num_time_steps=10)
 
     assert s.shape == (3, 10, 27)
+    assert a.shape == (3, 10, action_shape)
+    assert r.shape == (3, 10, 1)
+    assert d.shape == (3, 10, 1)
+    data_loader.close()
+
+
+@pytest.mark.parametrize("env_name", [
+    "Ant-v4",
+])
+def test_data_loader_weight_perturbation(env_name):
+    num_time_steps = 18
+    env = gym.make(env_name, render_mode="rgb_array")
+    action_shape, = env.action_space.shape
+
+    encoder = ConvEncoder(
+        input_shape=(3, 64, 64),
+        embed_size=1024,
+        activation=torch.nn.ReLU(),
+        depth=32
+    )
+
+    actor = Actor(
+        input_dim=1024,
+        output_dim=8,
+        bound=1,
+        num_layers=3,
+        hidden_dim=512,
+    )
+
+    policy = EncoderActor(
+        encoder=encoder,
+        actor=actor,
+        num_latent=32,
+        num_cat=32
+    )
+
+    weight_perturbation_size = 0.01
+    data_loader = EnvDataLoader(
+        num_time_steps=num_time_steps + 1,
+        state_shape=(3, 64, 64),
+        use_imgs_as_states=True,
+        env=env,
+        noise_size=0.0,
+        weight_perturbation_size=weight_perturbation_size,
+        policy=policy
+    )
+
+    for _ in range(4):
+        data_loader.perform_rollout()
+    for i in range(4):
+        assert data_loader.end_index[i] >= num_time_steps, f'{data_loader.end_index=}'
+        assert torch.all(data_loader.state_buffer[i, data_loader.end_index[i]+1:] == 0)
+        assert torch.all(data_loader.action_buffer[i, data_loader.end_index[i]+1:] == 0)
+        assert torch.all(data_loader.reward_buffer[i, data_loader.end_index[i]+1:] == 0)
+
+    s, a, r, d = data_loader.sample(batch_size=3, num_time_steps=10)
+
+    assert s.shape == (3, 10, 3, 64, 64)
     assert a.shape == (3, 10, action_shape)
     assert r.shape == (3, 10, 1)
     assert d.shape == (3, 10, 1)


### PR DESCRIPTION
# What is this:

this PR adds the ability to introduce noise to rollouts by perturbing the actor weights rather than just adding noise to the output action.

See [this](https://colab.research.google.com/drive/1K35W97xKIu00tP44sWDAO9T6C7Tj3G18) and [this](https://colab.research.google.com/drive/1qlu25ha3IAsSt8kGurT4-6XEHZR9BgEV#scrollTo=h2YjNpooauT3) for a comparison of the two behaviours. [This notebook](https://colab.research.google.com/drive/10OPNr4Sgqo0xIyWEGpwTJtkqpzDvfamB#scrollTo=4n1lJVq8vX8y) tests training performance.