### PR TITLE
Add training mask to world-model udpate

### DIFF
--- a/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
+++ b/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
@@ -133,6 +133,37 @@ def test_world_model(timesteps, return_init_states, encoder, decoder, dynamic_mo
 
 @pytest.mark.parametrize("timesteps", [16])
 @pytest.mark.parametrize("return_init_states", [True, False])
+def test_world_model_update_with_mask(timesteps, return_init_states, encoder, decoder, dynamic_model_8d_action):
+    dm = dynamic_model_8d_action
+    wm = WorldModel(
+        encoder=encoder, 
+        decoder=decoder,
+        dynamic_model=dm,
+    )
+
+    o = torch.zeros((2, timesteps+1, 3, 64, 64))
+    a = torch.zeros((2, timesteps+1, 8))
+    r = torch.zeros((2, timesteps+1, 1))
+    d = torch.zeros((2, timesteps+1, 1))
+    training_mask = torch.randint(0, 2, (2, timesteps+1))
+
+    if return_init_states:
+        results, (z, a, r, d) = wm.update(o, a, r, d, training_mask=training_mask, return_init_states=return_init_states)
+        assert z.shape == (2*(timesteps + 1), 1, 1024)
+        assert a.shape == (2*(timesteps + 1), 1, 8)
+        assert r.shape == (2*(timesteps + 1), 1, 1)
+        assert d.shape == (2*(timesteps + 1), 1, 1)
+    else:
+        results = wm.update(o, a, r, d, training_mask=training_mask,)
+
+    for key in ['recon_loss', 'reg_loss',
+                'consistency_loss', 'dynamic_loss',
+                'reward_loss', 'done_loss']:
+        assert key in asdict(results)
+
+
+@pytest.mark.parametrize("timesteps", [16])
+@pytest.mark.parametrize("return_init_states", [True, False])
 def test_state_world_model(timesteps, return_init_states, state_encoder, state_decoder, dynamic_model_8d_action):
     dm = dynamic_model_8d_action
     wm = WorldModel(

--- a/src/reflect/components/transformer_world_model/world_model.py
+++ b/src/reflect/components/transformer_world_model/world_model.py
@@ -110,7 +110,7 @@ class WorldModel(Base):
         if params is None:
             params = self.params
         if training_mask is None:
-            training_mask = torch.ones(o.shape[:2])
+            training_mask = torch.ones(o.shape[:2]).to(o.device)
         b, t, *_  = o.shape
 
         z, z_logits = self.encode(o)

--- a/src/reflect/components/transformer_world_model/world_model.py
+++ b/src/reflect/components/transformer_world_model/world_model.py
@@ -103,11 +103,14 @@ class WorldModel(Base):
             a: torch.Tensor,
             r: torch.Tensor,
             d: torch.Tensor,
+            training_mask: Optional[torch.Tensor] = None,
             params: Optional[WorldModelTrainingParams] = None,
             return_init_states: bool=False
         ):
         if params is None:
             params = self.params
+        if training_mask is None:
+            training_mask = torch.ones(o.shape[:2])
         b, t, *_  = o.shape
 
         z, z_logits = self.encode(o)
@@ -125,17 +128,23 @@ class WorldModel(Base):
         z = z.detach()
         _, num_z, num_c = z_logits.shape
         z_logits = z_logits.reshape(b, t, num_z, num_c)
-        r_targets = r[:, 1:].detach()
-        d_targets = d[:, 1:].detach()
-        z_logits = z_logits[:, 1:]
+        training_mask_targets = training_mask[:, 1:].detach()
+
+        r_targets = r[:, 1:].detach() * training_mask_targets[:, :, None]
+        d_targets = d[:, 1:].detach() * training_mask_targets[:, :, None]
+        z_logits = z_logits[:, 1:] * training_mask_targets[:, :, None, None]
         next_z_dist = create_z_dist(z_logits.detach())
         c_z_dist = create_z_dist(z_logits)
         
-        z_inputs, r_inputs, a_inputs = (
+        z_inputs, r_inputs, a_inputs, training_mask_inputs = (
             z[:, :-1].detach(),
             r[:, :-1].detach(),
-            a[:, :-1].detach()
+            a[:, :-1].detach(),
+            training_mask[:, :-1].detach()
         )
+
+        z_inputs = z_inputs * training_mask_inputs[:, :, None]
+        r_inputs = r_inputs * training_mask_inputs[:, :, None]
 
         z_pred, r_pred, d_pred = self.dynamic_model(
             z_inputs, a_inputs, r_inputs,


### PR DESCRIPTION
# What is this:

Adds a training mask which can be used to prevent the model learning from specific items in the sequence. It just sets those terms to zero. Note that the zero terms in the sequence are still passed through to the transformer and so may be use for predicting later states.

## Note:

This is motivated by a need to filter states in a sequence that might be corrupted. In the case of RL in real physical use cases you might get things like sensor dropouts that cause the reward function or states to be inaccurate.

### Tests:

1. Performance test: [in-govern-fed](https://colab.research.google.com/drive/1n3ZvzUYmf-w8_VZoJ8RIE_wwv00Vpqsk#scrollTo=uJbIWZZchamE) - Note that this change isn't a training performance enhancement.
2. Regression test: [zip-cube-fair](https://colab.research.google.com/drive/1nyA2WkoNI6BJvf1PcKVagZ-qA8JZx4oR)