### PR TITLE
Add intermittent noise

### DIFF
--- a/src/reflect/data/loader.py
+++ b/src/reflect/data/loader.py
@@ -78,7 +78,8 @@ class EnvDataLoader:
             ),
             noise_generator=None,
             seed=None,
-            noise_size=0.05,
+            noise_size=0.3,
+            noise_prob=0.2,
             weight_perturbation_size=0.01,
             use_imgs_as_states=True
         ):
@@ -93,6 +94,7 @@ class EnvDataLoader:
         self.env = env
         self.seed = seed
         self.noise_size = noise_size
+        self.noise_prob = noise_prob
         self.use_imgs_as_states = use_imgs_as_states
         _ = self.env.reset()
         self.action_dim = self.env.action_space.shape[0]
@@ -202,7 +204,8 @@ class EnvDataLoader:
     def compute_action(self, observation):
         if self.policy:
             action = self.policy(observation)
-            action = action + torch.normal(torch.zeros_like(action), self.noise_size)
+            if torch.rand(1) < self.noise_prob:
+                action = action + torch.normal(torch.zeros_like(action), self.noise_size)
             # action = action.squeeze(0)
             action = action.squeeze()
         else:


### PR DESCRIPTION
# What is this

This pr adds Intermittent noise to the data loader. Instead of always adding noise to actions when sampling from the environment, with this change we add an option so that the user can do so only `noise_prob` proportion of the time.

Performance test [here](https://colab.research.google.com/drive/12AzFB2D-oAfrkUf0rTzDkYZNbCU6qObR#scrollTo=h2YjNpooauT3).

No notable improvement