### PR TITLE
Add actor entropy for transformer world model and value trainer

### DIFF
--- a/src/reflect/components/trainers/value/value_trainer.py
+++ b/src/reflect/components/trainers/value/value_trainer.py
@@ -153,7 +153,7 @@ class ValueGradTrainer:
         self.critic_optim.update_parameters()
 
         if entropy is not None:
-            entropy = - entropy.mean()
+            entropy = entropy.mean()
             actor_loss = - target_values.mean() - self.eta * entropy
             entropy_loss = entropy.item()
         else:

--- a/src/reflect/components/trainers/value/value_trainer.py
+++ b/src/reflect/components/trainers/value/value_trainer.py
@@ -139,7 +139,7 @@ class ValueGradTrainer:
             state_samples,
             reward_samples,
             done_samples,
-            action_distribution_samples=None
+            entropy=None
         ):
         value_loss, target_values = self.value_loss(
             state_samples=state_samples,
@@ -152,8 +152,8 @@ class ValueGradTrainer:
         )
         self.critic_optim.update_parameters()
 
-        if action_distribution_samples is not None:
-            entropy = - action_distribution_samples.entropy().mean()
+        if entropy is not None:
+            entropy = - entropy.mean()
             actor_loss = - target_values.mean() - self.eta * entropy
             entropy_loss = entropy.item()
         else:

--- a/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
+++ b/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
@@ -255,3 +255,34 @@ def test_state_world_model_imagine_rollout(
     assert a.shape == (34, 26, 8)
     assert r.shape == (34, 26, 1)
     assert d.shape == (34, 26, 1)
+
+
+@pytest.mark.parametrize("timesteps", [16])
+def test_world_model_imagine_rollout_non_deterministic(
+        timesteps,
+        state_encoder,
+        state_decoder,
+        dynamic_model_8d_action,
+        actor
+    ):
+    dm = dynamic_model_8d_action
+    wm = WorldModel(
+        encoder=state_encoder, 
+        decoder=state_decoder,
+        dynamic_model=dm,
+    )
+    o = torch.zeros((2, timesteps+1, 27))
+    a = torch.zeros((2, timesteps+1, 8))
+    r = torch.zeros((2, timesteps+1, 1))
+    d = torch.zeros((2, timesteps+1, 1))
+    _, (z, a, r, d) = wm.update(o, a, r, d, return_init_states=True)
+    z, a, r, d, entropy = wm.imagine_rollout(
+        z=z, a=a, r=r, d=d,
+        actor=actor,
+        with_entropies=True
+    )
+    assert z.shape == (34, 26, 1024)
+    assert a.shape == (34, 26, 8)
+    assert r.shape == (34, 26, 1)
+    assert d.shape == (34, 26, 1)
+    assert entropy.shape == (34, 26, 1)


### PR DESCRIPTION
# What is this

This PR:

1. Adds a parameter to the `imagine_rollout` method of the world_model to allow the entropy to be returned from the actor for each time step. Implicitly using this causes the actor to be stochastic instead of deterministic.
2. Allows the value trainer to receive a tensor of entropies and combine them into the actor loss in order to ensure exploration. The entropy regulariser term is weighted by an eta value set at init which defaults to `0.001`.

Performance test [here](https://colab.research.google.com/drive/1aLoQEUOpHaFKxSIQJZLe2oEt2XDsd5yh#scrollTo=uJbIWZZchamE)