### PR TITLE
Add no_update bool to world model update method

### DIFF
--- a/src/reflect/components/transformer_world_model/world_model.py
+++ b/src/reflect/components/transformer_world_model/world_model.py
@@ -105,7 +105,8 @@ class WorldModel(Base):
             d: torch.Tensor,
             training_mask: Optional[torch.Tensor] = None,
             params: Optional[WorldModelTrainingParams] = None,
-            return_init_states: bool=False
+            return_init_states: bool=False,
+            no_update: bool=False
         ):
         if params is None:
             params = self.params
@@ -173,8 +174,14 @@ class WorldModel(Base):
 
         dynamic_grad_norm = self.dynamic_model_opt.backward(dyn_loss, retain_graph=False)
         observation_grad_norm = self.observation_model_opt.backward(obs_loss, retain_graph=False)
-        self.dynamic_model_opt.update_parameters()
-        self.observation_model_opt.update_parameters()
+        
+        if no_update:
+            self.dynamic_model_opt.zero_grad()
+            self.observation_model_opt.zero_grad()
+        else:
+            self.dynamic_model_opt.update_parameters()
+            self.observation_model_opt.update_parameters()
+
         losses = WorldModelLosses(
             recon_loss=recon_loss.detach().cpu().item(),
             reg_loss= reg_loss.detach().cpu().item(),

--- a/src/reflect/utils.py
+++ b/src/reflect/utils.py
@@ -24,6 +24,9 @@ class AdamOptim:
     def update_parameters(self):
         self.optimizer.step()
 
+    def zero_grad(self):
+        self.optimizer.zero_grad()
+
     def load_state_dict(self, state_dict):
         self.optimizer.load_state_dict(state_dict)
 


### PR DESCRIPTION
# What is this?

This PR adds `no_update` boolean argument to the `world_model.update` method. This enables users to compute a validation loss.