### PR TITLE
Add action scaling to actor

### DIFF
--- a/src/reflect/components/models/actor.py
+++ b/src/reflect/components/models/actor.py
@@ -50,7 +50,7 @@ class Actor(torch.nn.Module):
     def forward(self, x, deterministic=False):
         x = self.layers(x)
         mu = self.mu(x)
-        mu = torch.tanh(mu / self.action_scale) * (self.action_scale * self.bound)
+        mu = torch.tanh(mu / self.action_scale) * self.bound
         if deterministic:
             return mu
 


### PR DESCRIPTION
Adds the following:

> The action model outputs a tanh mean scaled by a factor of 5 and a softplus standard deviation for the Normal distribution that is then transformed using tanh (Haarnoja et al., 2018). The scaling factor allows the agent to saturate the action distribution.

from [dreamerv1 paper](https://arxiv.org/pdf/1912.01603 p14)

1. [quadruped regression test](https://colab.research.google.com/drive/1CP2JllCYtFyrbWerPQdG5VaWEsXyw8Ow#scrollTo=h2YjNpooauT3)
2. [walker regression test](https://colab.research.google.com/drive/1ohOM_9MTXqJEtNsEDQChueF_YZQRKhZO#scrollTo=pEy1rLE6msSx)
