### PR TITLE
Fix reconstruction loss bug

### DIFF
--- a/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
+++ b/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
@@ -149,13 +149,20 @@ def test_state_world_model(return_init_states, training_mask, state_encoder, sta
     d = torch.zeros((2, timesteps+1, 1))
 
     if return_init_states:
-        results, (z, a, r, d) = wm.update(o, a, r, d, training_mask=training_mask, return_init_states=return_init_states)
+        results, (z, a, r, d) = wm.update(
+            o, a, r, d,
+            training_mask=training_mask,
+            return_init_states=return_init_states
+        )
         assert z.shape == (2*(timesteps + 1), 1, 1024)
         assert a.shape == (2*(timesteps + 1), 1, 8)
         assert r.shape == (2*(timesteps + 1), 1, 1)
         assert d.shape == (2*(timesteps + 1), 1, 1)
     else:
-        results = wm.update(o, a, r, d, training_mask=training_mask,)
+        results = wm.update(
+            o, a, r, d,
+            training_mask=training_mask,
+        )
 
     for key in ['recon_loss', 'reg_loss',
                 'consistency_loss', 'dynamic_loss',
@@ -169,8 +176,7 @@ def test_save_load(tmp_path, encoder, decoder, dynamic_model_8d_action):
         encoder=encoder,
         decoder=decoder,
         dynamic_model=dm,
-    )    
-
+    )
     wm.save(tmp_path)
     wm.load(tmp_path)
 
@@ -181,8 +187,7 @@ def test_state_save_load(tmp_path, state_encoder, state_decoder, dynamic_model_8
         encoder=state_encoder,
         decoder=state_decoder,
         dynamic_model=dm,
-    )    
-
+    )
     wm.save(tmp_path)
     wm.load(tmp_path)
 

--- a/src/reflect/utils.py
+++ b/src/reflect/utils.py
@@ -55,7 +55,7 @@ def recon_loss_fn(x, y):
         x, y = x.permute(0, 2, 3, 1), y.permute(0, 2, 3, 1)
         y_dist = D.Independent(D.Normal(y, torch.ones_like(y)), 3)
     elif len(x.shape) == 2:
-        y_dist = D.Independent(D.Normal(y, torch.ones_like(y)), 2)
+        y_dist = D.Independent(D.Normal(y, torch.ones_like(y)), 1)
     else:
         raise ValueError(f"Expected input shape to be 3 or 4, got {len(x.shape)}")
     return - y_dist.log_prob(x).mean()

--- a/src/reflect/utils.py
+++ b/src/reflect/utils.py
@@ -51,13 +51,12 @@ class AdamOptim:
 
 def recon_loss_fn(x, y):
     if len(x.shape) == 4:
-        # do we need to permute?
         x, y = x.permute(0, 2, 3, 1), y.permute(0, 2, 3, 1)
         y_dist = D.Independent(D.Normal(y, torch.ones_like(y)), 3)
     elif len(x.shape) == 2:
         y_dist = D.Independent(D.Normal(y, torch.ones_like(y)), 1)
     else:
-        raise ValueError(f"Expected input shape to be 3 or 4, got {len(x.shape)}")
+        raise ValueError(f"Expected input shape to be 2 or 4, got {len(x.shape)}")
     return - y_dist.log_prob(x).mean()
 
 
@@ -73,6 +72,7 @@ def create_z_dist(logits, temperature=1):
     assert temperature > 0
     dist = D.OneHotCategoricalStraightThrough(logits=logits / temperature)
     return D.Independent(dist, 1)
+
 
 def cross_entropy_loss_fn(z, z_hat, training_mask=None):
     """
@@ -137,7 +137,6 @@ class CSVLogger:
                 axs[i].set_title(fields)
                 axs[i].legend()
         plt.show()
-
 
 
 # see https://github.com/juliusfrost/dreamer-pytorch/blob/main/dreamer/utils/module.py


### PR DESCRIPTION
# What is this

Reconstruction loss for the training from state space case treats the batch and state dimensions as event dimensions rather than just the state? i.e. batch and state events should be independent but they are not.  See
1. [walker-walk env test](https://colab.research.google.com/drive/1gM8ffwTGnJtzjZD-xApjNuWiZSHB5Rfk#scrollTo=4n1lJVq8vX8y) 
2. [quadruped-walk env test](https://colab.research.google.com/drive/1k5vnMRYZ43AwCqX-yKX5CVwvJUx0fik1#scrollTo=4n1lJVq8vX8y)

Notes: 
- The above doesn't actually seem to have any significant effect as far as I can tell?
- Similar error exists in the RSSM case, I just can't be bothered rerunning the RSSM notebooks (TODO)
