### PR TITLE
Fix mask for generation issue

### DIFF
--- a/src/reflect/components/transformer_world_model/embedder.py
+++ b/src/reflect/components/transformer_world_model/embedder.py
@@ -38,7 +38,7 @@ class StackEmbedder(BaseEmbedder):
             hidden_dim=hidden_dim,
         )
 
-    def forward(self, x):
+    def forward(self, x, *args, **kwargs):
         s, a, r = x
         b, *_ = s.shape
         a_emb = self.a_emb(a)
@@ -63,7 +63,7 @@ class AddEmbedder(BaseEmbedder):
             hidden_dim=hidden_dim,
         )
 
-    def forward(self, x):
+    def forward(self, x, *args, **kwargs):
         s, a, r = x
         b, *_ = s.shape
         a_emb = self.a_emb(a)
@@ -85,7 +85,7 @@ class ConcatEmbedder(BaseEmbedder):
             hidden_dim=hidden_dim,
         )
 
-    def forward(self, x):
+    def forward(self, x, *args, **kwargs):
         s, a, r = x
         b, *_ = s.shape
         a_emb = self.a_emb(a)

--- a/src/reflect/components/transformer_world_model/transformer.py
+++ b/src/reflect/components/transformer_world_model/transformer.py
@@ -85,9 +85,9 @@ class PytfexTransformer(torch.nn.Module):
             d: torch.Tensor,
         ):
         _, l, _ = z.shape
-        # embedder might be more complicated...
         mask_len = min(self.ts_adjuster*l, self.num_ts*self.ts_adjuster)
         mask = get_causal_mask(mask_len)
+        mask = mask.to(z.device)
         input = (
             z[:, -self.num_ts:],
             a[:, -self.num_ts:],

--- a/src/reflect/components/transformer_world_model/transformer.py
+++ b/src/reflect/components/transformer_world_model/transformer.py
@@ -41,7 +41,8 @@ class PytfexTransformer(torch.nn.Module):
         self.num_cat = num_cat
         self.latent_dim = latent_dim
         head_cls, embedder_cls, ts_adjuster, hdn_adj = head_embedder_class_map[embedding_type]
-        num_ts = self.num_ts * ts_adjuster
+        self.ts_adjuster = ts_adjuster
+        num_ts = self.num_ts * self.ts_adjuster
         internal_hdn_dim = hdn_adj * hdn_dim
         self.mask = get_causal_mask(num_ts)
 
@@ -83,11 +84,19 @@ class PytfexTransformer(torch.nn.Module):
             r: torch.Tensor,
             d: torch.Tensor,
         ):
-        z_dist, new_r, new_d = self.dynamic_model((
+        _, l, _ = z.shape
+        # embedder might be more complicated...
+        mask_len = min(self.ts_adjuster*l, self.num_ts*self.ts_adjuster)
+        mask = get_causal_mask(mask_len)
+        input = (
             z[:, -self.num_ts:],
             a[:, -self.num_ts:],
-            r[:, -self.num_ts:]
-        ))
+            r[:, -self.num_ts:],
+        )
+        z_dist, new_r, new_d = self.dynamic_model(
+            input,
+            mask=mask
+        )
 
         new_r = new_r[:, -1].reshape(-1, 1, 1)
         r = torch.cat([r, new_r], dim=1)


### PR DESCRIPTION
## What is this

This PR 

1. Makes the repo compatible with the latest [transformers](https://github.com/mauicv/transformers) work.
2. Fixes the absence of a mask in imagination rollouts.


see [deaf-opening-smart](https://colab.research.google.com/drive/1qZLLc5mx31V_DBzrP7se-0VAt_jqRPkP#scrollTo=4n1lJVq8vX8y) for `dm_control` walker walk regression test