### PR TITLE
Feature/kv cache

### DIFF
--- a/src/reflect/components/transformer_world_model/tests/test_ppo_trainer.py
+++ b/src/reflect/components/transformer_world_model/tests/test_ppo_trainer.py
@@ -65,7 +65,8 @@ def test_update(encoder, decoder, actor):
         z=z, a=a, r=r, d=d,
         actor=actor,
         with_observations=False,
-        disable_gradients=True
+        disable_gradients=True,
+        num_timesteps=16,
     )
 
     history = trainer.update(
@@ -136,7 +137,8 @@ def test_update_state(state_encoder, state_decoder, actor):
         z=z, a=a, r=r, d=d,
         actor=actor,
         with_observations=False,
-        disable_gradients=True
+        disable_gradients=True,
+        num_timesteps=16,
     )
 
     history = trainer.update(

--- a/src/reflect/components/transformer_world_model/tests/test_td3_trainer.py
+++ b/src/reflect/components/transformer_world_model/tests/test_td3_trainer.py
@@ -64,7 +64,8 @@ def test_update(encoder, decoder, actor):
         z=z, a=a, r=r, d=d,
         actor=actor,
         with_observations=False,
-        disable_gradients=True
+        disable_gradients=True,
+        num_timesteps=16
     )
 
     history = trainer.update(
@@ -137,6 +138,7 @@ def test_update_state(state_encoder, state_decoder, actor):
         with_observations=False,
         disable_gradients=True,
         with_entropies=True,
+        num_timesteps=16,
     )
 
     history = trainer.update(

--- a/src/reflect/components/transformer_world_model/tests/test_value_trainer.py
+++ b/src/reflect/components/transformer_world_model/tests/test_value_trainer.py
@@ -53,7 +53,8 @@ def test_update(encoder, decoder, actor):
     z, a, r, d = wm.imagine_rollout(
         z=z, a=a, r=r, d=d,
         actor=actor,
-        with_observations=False
+        with_observations=False,
+        num_timesteps=16,
     )
 
     history = trainer.update(
@@ -111,7 +112,8 @@ def test_update_state(state_encoder, state_decoder, actor):
     z, a, r, d = wm.imagine_rollout(
         z=z, a=a, r=r, d=d,
         actor=actor,
-        with_observations=False
+        with_observations=False,
+        num_timesteps=16,
     )
 
     history = trainer.update(

--- a/src/reflect/components/transformer_world_model/transformer.py
+++ b/src/reflect/components/transformer_world_model/transformer.py
@@ -86,11 +86,6 @@ class PytfexTransformer(torch.nn.Module):
             kv_cache: Optional[KVCache]=None,
         ):
         _, l, _ = z.shape
-        # mask_len = min(self.ts_adjuster*l, self.num_ts*self.ts_adjuster)
-        # mask = get_causal_mask(mask_len)
-        # mask = mask.to(z.device)
-        
-        # TODO: should adjust for kv_cache lengthy???
         inputs = (
             z[:, -1:],
             a[:, -1:],
@@ -98,7 +93,6 @@ class PytfexTransformer(torch.nn.Module):
         )
         (z_dist, new_r, new_d), kv_cache = self.dynamic_model(
             inputs,
-            # mask=mask,
             use_kv_cache=True,
             kv_cache=kv_cache,
         )


### PR DESCRIPTION
## What is this

This PR uses the transformer world model kv_cache  during rollouts. See related pr [1.](https://github.com/mauicv/transformers/pull/15) and [2.](https://github.com/mauicv/transformers/pull/13) in [transformers lib](https://github.com/mauicv/transformers).

- [regression test](https://colab.research.google.com/drive/1sNrnyD0lWzFrX1xumGZ_JHWECTjop291#scrollTo=4n1lJVq8vX8y)


### Time tests:

1. Using [main branch](https://colab.research.google.com/drive/1Mkb6mnt-Uj7heAIoByU4MusiSbmIyTKn#scrollTo=tthyi1je2VKR) at commit `8feecbd3c01a376d287ccc5f1eabb4fa6fc0e6c6`

<img width="1189" height="790" alt="image" src="https://github.com/user-attachments/assets/62642a07-4308-438b-99f6-2bd835db5e1e" />

2. Using [feature/kv-cache](https://colab.research.google.com/drive/11x3ZB5tkPnMoOpCr_69W4A2ETJL-_PA_#scrollTo=tthyi1je2VKR)

<img width="1189" height="790" alt="image" src="https://github.com/user-attachments/assets/88ecd1d0-bef9-4f0a-8902-3c535dd501ce" />

average time for old method (1.290s) and average time for new (0.818) so 2/3 of the time. Note this is relative attention and the approach I've taken doesn't capture all available speed ups. See [this](https://github.com/mauicv/transformers/issues/14) issue and also [this](https://github.com/mauicv/transformers/issues/16) issue.