### PR TITLE
Enable rollouts without utilizing the kvcache for PPO training

### DIFF
--- a/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
+++ b/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
@@ -310,3 +310,34 @@ def test_world_model_imagine_rollout_non_deterministic(
     assert r.shape == (34, 17, 1)
     assert d.shape == (34, 17, 1)
     assert entropy.shape == (34, 17, 1)
+
+
+@pytest.mark.parametrize("timesteps", [16])
+def test_world_model_imagine_rollout_no_kvcache(
+        timesteps,
+        state_encoder,
+        state_decoder,
+        dynamic_model_8d_action,
+        actor
+    ):
+    dm = dynamic_model_8d_action
+    wm = WorldModel(
+        encoder=state_encoder, 
+        decoder=state_decoder,
+        dynamic_model=dm,
+    )
+    o = torch.zeros((2, timesteps+1, 27))
+    a = torch.zeros((2, timesteps+1, 8))
+    r = torch.zeros((2, timesteps+1, 1))
+    d = torch.zeros((2, timesteps+1, 1))
+    _, (z, a, r, d) = wm.update(o, a, r, d, return_init_states=True)
+    z, a, r, d = wm.imagine_rollout(
+        z=z, a=a, r=r, d=d,
+        use_kv_cache=False,
+        actor=actor,
+        num_timesteps=24,
+    )
+    assert z.shape == (34, 25, 1024)
+    assert a.shape == (34, 25, 8)
+    assert r.shape == (34, 25, 1)
+    assert d.shape == (34, 25, 1)

--- a/src/reflect/components/transformer_world_model/transformer.py
+++ b/src/reflect/components/transformer_world_model/transformer.py
@@ -84,18 +84,31 @@ class PytfexTransformer(torch.nn.Module):
             r: torch.Tensor,
             d: torch.Tensor,
             kv_cache: Optional[KVCache]=None,
+            use_kv_cache: bool=True,
         ):
         _, l, _ = z.shape
-        inputs = (
-            z[:, -1:],
-            a[:, -1:],
-            r[:, -1:],
-        )
-        (z_dist, new_r, new_d), kv_cache = self.dynamic_model(
-            inputs,
-            use_kv_cache=True,
-            kv_cache=kv_cache,
-        )
+        if use_kv_cache:
+            inputs = (
+                z[:, -1:],
+                a[:, -1:],
+                r[:, -1:],
+            )
+            (z_dist, new_r, new_d), kv_cache = self.dynamic_model(
+                inputs,
+                use_kv_cache=True,
+                kv_cache=kv_cache,
+            )
+        else:
+            inputs = (
+                z[:, -self.num_ts:],
+                a[:, -self.num_ts:],
+                r[:, -self.num_ts:],
+            )
+            (z_dist, new_r, new_d) = self.dynamic_model(
+                inputs,
+                use_kv_cache=False,
+            )
+            kv_cache = None
 
         new_r = new_r[:, -1].reshape(-1, 1, 1)
         r = torch.cat([r, new_r], dim=1)
@@ -112,8 +125,9 @@ class PytfexTransformer(torch.nn.Module):
             r: torch.Tensor,
             d: torch.Tensor,
             kv_cache: Optional[KVCache]=None,
+            use_kv_cache: bool=True,
         ):
-        z_dist, new_r, new_d, kv_cache = self._step(z, a, r, d, kv_cache)
+        z_dist, new_r, new_d, kv_cache = self._step(z, a, r, d, kv_cache, use_kv_cache)
         new_z = z_dist.sample()
         new_z = new_z[:, -1].reshape(-1, 1, self.num_cat * self.latent_dim)
         new_z = torch.cat([z, new_z], dim=1)
@@ -126,8 +140,9 @@ class PytfexTransformer(torch.nn.Module):
             r: torch.Tensor,
             d: torch.Tensor,
             kv_cache: Optional[KVCache]=None,
+            use_kv_cache: bool=True,
         ):
-        z_dist, new_r, new_d, kv_cache = self._step(z, a, r, d, kv_cache)
+        z_dist, new_r, new_d, kv_cache = self._step(z, a, r, d, kv_cache, use_kv_cache)
         new_z = z_dist.rsample()
         new_z = new_z[:, -1].reshape(-1, 1, self.num_cat * self.latent_dim)
         new_z = torch.cat([z, new_z], dim=1)

--- a/src/reflect/components/transformer_world_model/world_model.py
+++ b/src/reflect/components/transformer_world_model/world_model.py
@@ -222,9 +222,38 @@ class WorldModel(Base):
             actor: Actor,
             num_timesteps: int=25,
             with_observations: bool=False,
+            use_kv_cache: bool=True,
             with_entropies: bool=False,
             disable_gradients: bool=False,
-            # use_kv_cache: bool=False,
+        ):
+        if use_kv_cache:
+            return self._imagine_rollout_kvcache(
+                z=z, a=a, r=r, d=d,
+                actor=actor,
+                num_timesteps=num_timesteps,
+                with_observations=with_observations,
+                with_entropies=with_entropies,
+                disable_gradients=disable_gradients,
+            )
+        else:
+            return self._imagine_rollout(
+                z=z, a=a, r=r, d=d,
+                actor=actor,
+                num_timesteps=num_timesteps,
+                with_observations=with_observations,
+            )
+
+    def _imagine_rollout_kvcache(
+            self,
+            z: torch.Tensor,
+            a: torch.Tensor,
+            r: torch.Tensor,
+            d: torch.Tensor,
+            actor: Actor,
+            num_timesteps: int=25,
+            with_observations: bool=False,
+            with_entropies: bool=False,
+            disable_gradients: bool=False,
         ):
 
         with torch.set_grad_enabled(not disable_gradients):    
@@ -267,6 +296,46 @@ class WorldModel(Base):
                     # Stack the entropies along time dimension
                     entropy = torch.stack(entropies, dim=1)  # [batch, time, 1]
                     to_return.append(entropy)
+                if with_observations:
+                    b, t, *_ = z.shape
+                    o = self.decode(z.reshape(b*t, -1))
+                    o = o.reshape(b, t, *o.shape[1:])
+                    to_return.append(o)
+                return to_return
+
+    def _imagine_rollout(
+            self,
+            z: torch.Tensor,
+            a: torch.Tensor,
+            r: torch.Tensor,
+            d: torch.Tensor,
+            actor: Actor,
+            num_timesteps: int=25,
+            with_observations: bool=False,
+        ):
+
+        with torch.no_grad():    
+            with FreezeParameters([self.dynamic_model, self.decoder, actor]):
+                for i in range(num_timesteps):
+                    z, r, d, kv_cache = self \
+                        .dynamic_model.step(
+                            z=z, a=a, r=r, d=d,
+                            kv_cache=None,
+                            use_kv_cache=False,
+                        )
+                    action_dist = actor(
+                        z[:, -1, :].detach(),
+                        deterministic=False
+                    )
+                    action = action_dist.sample()
+                    if self.environment_action_bound is not None:
+                        action = torch.clamp(
+                            action,
+                            min=-self.environment_action_bound,
+                            max=self.environment_action_bound
+                        )
+                    a = torch.cat((a, action[:, None, :]), dim=1)
+                to_return = [z, a, r, d]
                 if with_observations:
                     b, t, *_ = z.shape
                     o = self.decode(z.reshape(b*t, -1))


### PR DESCRIPTION
 # What is this

imagining beyond the number of timestep tokens trained on while using kv-cache doesn't work because it requires recomputing the kv-cache to accommodate shifted tokens. In order to enable longer rollouts i've added a method to make generating rollouts without the kv-cache possible. 

see [this](https://colab.research.google.com/drive/1SedL4tw42Zl-yOGohZkGTNOJendIa3ew?authuser=1#scrollTo=4n1lJVq8vX8y) notebook and [this](https://colab.research.google.com/drive/1-AOPr9yeHjT3TAqDu5N6_nhy5xzyh0tp?authuser=1#scrollTo=uJbIWZZchamE) notebook.