### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a pure-Python ML/RL research library (`world-model-rl`). No web services, databases, or containers needed.
+
+### Quick reference
+
+| Action | Command |
+|--------|---------|
+| Install deps | `source venv/bin/activate && pip install -e .` |
+| Run tests | `source venv/bin/activate && pytest src` |
+| Run example | `source venv/bin/activate && python src/reflect/examples/differential_rl/basic.py` |
+
+### Non-obvious notes
+
+- **`torchvision` is an implicit dependency** not listed in `pyproject.toml` but required at runtime (imported in `reflect.data.loader`). The update script installs it explicitly.
+- **2 tests fail on PyTorch >=2.6** (`test_save_and_load`, `test_save_load`) due to the `weights_only=True` default in `torch.load`. This is a pre-existing issue, not an environment problem.
+- **No linter is configured** in the repository (no ruff, flake8, pylint, mypy, or pyright config).
+- The `EnvDataLoader.sample()` returns a tuple `(b_inds, t_inds, states, actions, rewards, dones)`, not a dict.
+- MuJoCo is bundled automatically via `gymnasium[mujoco]`; no separate system install required.
+- The venv lives at `/workspace/venv`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions for the `world-model-rl` codebase.

## What's included

- Quick reference table for installing deps, running tests, and running examples
- Non-obvious notes about implicit `torchvision` dependency, pre-existing test failures on PyTorch >=2.6, and data loader API

## Environment verification

The development environment was verified end-to-end:

- **Dependencies**: `pip install -e .` + `torchvision` + `pytest` in a Python 3.12 venv
- **Tests**: 99/101 pass; 2 pre-existing failures due to PyTorch `weights_only=True` default change
- **Hello world**: Differentiable pendulum RL training (5 steps), MuJoCo InvertedPendulum-v4 env stepping, and `EnvDataLoader` rollout collection + sampling all work correctly

### Test output
[test_results.log](https://cursor.com/agents/bc-640405fe-0ed3-4ad2-b094-3b9e07cc100f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_results.log)

### Hello world demo output
[hello_world_demo.log](https://cursor.com/agents/bc-640405fe-0ed3-4ad2-b094-3b9e07cc100f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-640405fe-0ed3-4ad2-b094-3b9e07cc100f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-640405fe-0ed3-4ad2-b094-3b9e07cc100f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

