### PR TITLE
Enable transformer imagine rollout actor input space selection

### DIFF
--- a/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
+++ b/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
@@ -5,6 +5,22 @@ import torch
 import pytest
 
 
+class RecordingActor(torch.nn.Module):
+    def __init__(self, input_dim: int, action_dim: int = 8):
+        super().__init__()
+        self.policy = torch.nn.Linear(input_dim, action_dim)
+        self.last_input_dim = None
+
+    def forward(self, x, deterministic: bool = False):
+        self.last_input_dim = x.shape[-1]
+        mu = torch.tanh(self.policy(x))
+        if deterministic:
+            return mu
+        std = torch.ones_like(mu) * 0.1
+        dist = torch.distributions.normal.Normal(mu, std)
+        return torch.distributions.independent.Independent(dist, 1)
+
+
 @pytest.mark.parametrize("timesteps", [1])
 def test_world_model_step(timesteps, encoder, decoder, dynamic_model_8d_action):
     dm = dynamic_model_8d_action
@@ -341,3 +357,97 @@ def test_world_model_imagine_rollout_no_kvcache(
     assert a.shape == (34, 25, 8)
     assert r.shape == (34, 25, 1)
     assert d.shape == (34, 25, 1)
+
+
+def test_state_world_model_imagine_rollout_kvcache_actor_input_space_selection(
+        state_encoder,
+        state_decoder,
+        dynamic_model_8d_action,
+    ):
+    timesteps = 8
+    dm = dynamic_model_8d_action
+    wm = WorldModel(
+        encoder=state_encoder,
+        decoder=state_decoder,
+        dynamic_model=dm,
+    )
+    o = torch.zeros((2, timesteps + 1, 27))
+    a = torch.zeros((2, timesteps + 1, 8))
+    r = torch.zeros((2, timesteps + 1, 1))
+    d = torch.zeros((2, timesteps + 1, 1))
+    _, (z, a, r, d) = wm.update(o, a, r, d, return_init_states=True)
+
+    latent_actor = RecordingActor(input_dim=1024)
+    z_latent, a_latent, r_latent, d_latent = wm.imagine_rollout(
+        z=z, a=a, r=r, d=d,
+        actor=latent_actor,
+        actor_in_latent_space=True,
+        num_timesteps=8,
+        use_kv_cache=True,
+    )
+    assert latent_actor.last_input_dim == 1024
+    assert z_latent.shape == (18, 9, 1024)
+    assert a_latent.shape == (18, 9, 8)
+    assert r_latent.shape == (18, 9, 1)
+    assert d_latent.shape == (18, 9, 1)
+
+    reconstructed_actor = RecordingActor(input_dim=27)
+    z_obs, a_obs, r_obs, d_obs = wm.imagine_rollout(
+        z=z, a=a, r=r, d=d,
+        actor=reconstructed_actor,
+        actor_in_latent_space=False,
+        num_timesteps=8,
+        use_kv_cache=True,
+    )
+    assert reconstructed_actor.last_input_dim == 27
+    assert z_obs.shape == (18, 9, 1024)
+    assert a_obs.shape == (18, 9, 8)
+    assert r_obs.shape == (18, 9, 1)
+    assert d_obs.shape == (18, 9, 1)
+
+
+def test_state_world_model_imagine_rollout_no_kvcache_actor_input_space_selection(
+        state_encoder,
+        state_decoder,
+        dynamic_model_8d_action,
+    ):
+    timesteps = 8
+    dm = dynamic_model_8d_action
+    wm = WorldModel(
+        encoder=state_encoder,
+        decoder=state_decoder,
+        dynamic_model=dm,
+    )
+    o = torch.zeros((2, timesteps + 1, 27))
+    a = torch.zeros((2, timesteps + 1, 8))
+    r = torch.zeros((2, timesteps + 1, 1))
+    d = torch.zeros((2, timesteps + 1, 1))
+    _, (z, a, r, d) = wm.update(o, a, r, d, return_init_states=True)
+
+    latent_actor = RecordingActor(input_dim=1024)
+    z_latent, a_latent, r_latent, d_latent = wm.imagine_rollout(
+        z=z, a=a, r=r, d=d,
+        actor=latent_actor,
+        actor_in_latent_space=True,
+        num_timesteps=8,
+        use_kv_cache=False,
+    )
+    assert latent_actor.last_input_dim == 1024
+    assert z_latent.shape == (18, 9, 1024)
+    assert a_latent.shape == (18, 9, 8)
+    assert r_latent.shape == (18, 9, 1)
+    assert d_latent.shape == (18, 9, 1)
+
+    reconstructed_actor = RecordingActor(input_dim=27)
+    z_obs, a_obs, r_obs, d_obs = wm.imagine_rollout(
+        z=z, a=a, r=r, d=d,
+        actor=reconstructed_actor,
+        actor_in_latent_space=False,
+        num_timesteps=8,
+        use_kv_cache=False,
+    )
+    assert reconstructed_actor.last_input_dim == 27
+    assert z_obs.shape == (18, 9, 1024)
+    assert a_obs.shape == (18, 9, 8)
+    assert r_obs.shape == (18, 9, 1)
+    assert d_obs.shape == (18, 9, 1)

--- a/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
+++ b/src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py
@@ -364,7 +364,7 @@ def test_state_world_model_imagine_rollout_kvcache_actor_input_space_selection(
         state_decoder,
         dynamic_model_8d_action,
     ):
-    timesteps = 8
+    timesteps = 16
     dm = dynamic_model_8d_action
     wm = WorldModel(
         encoder=state_encoder,
@@ -386,10 +386,10 @@ def test_state_world_model_imagine_rollout_kvcache_actor_input_space_selection(
         use_kv_cache=True,
     )
     assert latent_actor.last_input_dim == 1024
-    assert z_latent.shape == (18, 9, 1024)
-    assert a_latent.shape == (18, 9, 8)
-    assert r_latent.shape == (18, 9, 1)
-    assert d_latent.shape == (18, 9, 1)
+    assert z_latent.shape == (34, 9, 1024)
+    assert a_latent.shape == (34, 9, 8)
+    assert r_latent.shape == (34, 9, 1)
+    assert d_latent.shape == (34, 9, 1)
 
     reconstructed_actor = RecordingActor(input_dim=27)
     z_obs, a_obs, r_obs, d_obs = wm.imagine_rollout(
@@ -400,10 +400,10 @@ def test_state_world_model_imagine_rollout_kvcache_actor_input_space_selection(
         use_kv_cache=True,
     )
     assert reconstructed_actor.last_input_dim == 27
-    assert z_obs.shape == (18, 9, 1024)
-    assert a_obs.shape == (18, 9, 8)
-    assert r_obs.shape == (18, 9, 1)
-    assert d_obs.shape == (18, 9, 1)
+    assert z_obs.shape == (34, 9, 1024)
+    assert a_obs.shape == (34, 9, 8)
+    assert r_obs.shape == (34, 9, 1)
+    assert d_obs.shape == (34, 9, 1)
 
 
 def test_state_world_model_imagine_rollout_no_kvcache_actor_input_space_selection(
@@ -411,7 +411,7 @@ def test_state_world_model_imagine_rollout_no_kvcache_actor_input_space_selectio
         state_decoder,
         dynamic_model_8d_action,
     ):
-    timesteps = 8
+    timesteps = 16
     dm = dynamic_model_8d_action
     wm = WorldModel(
         encoder=state_encoder,
@@ -433,10 +433,10 @@ def test_state_world_model_imagine_rollout_no_kvcache_actor_input_space_selectio
         use_kv_cache=False,
     )
     assert latent_actor.last_input_dim == 1024
-    assert z_latent.shape == (18, 9, 1024)
-    assert a_latent.shape == (18, 9, 8)
-    assert r_latent.shape == (18, 9, 1)
-    assert d_latent.shape == (18, 9, 1)
+    assert z_latent.shape == (34, 9, 1024)
+    assert a_latent.shape == (34, 9, 8)
+    assert r_latent.shape == (34, 9, 1)
+    assert d_latent.shape == (34, 9, 1)
 
     reconstructed_actor = RecordingActor(input_dim=27)
     z_obs, a_obs, r_obs, d_obs = wm.imagine_rollout(
@@ -447,7 +447,7 @@ def test_state_world_model_imagine_rollout_no_kvcache_actor_input_space_selectio
         use_kv_cache=False,
     )
     assert reconstructed_actor.last_input_dim == 27
-    assert z_obs.shape == (18, 9, 1024)
-    assert a_obs.shape == (18, 9, 8)
-    assert r_obs.shape == (18, 9, 1)
-    assert d_obs.shape == (18, 9, 1)
+    assert z_obs.shape == (34, 9, 1024)
+    assert a_obs.shape == (34, 9, 8)
+    assert r_obs.shape == (34, 9, 1)
+    assert d_obs.shape == (34, 9, 1)

--- a/src/reflect/components/transformer_world_model/tests/test_transformer_world_model_actor.py
+++ b/src/reflect/components/transformer_world_model/tests/test_transformer_world_model_actor.py
@@ -1,9 +1,12 @@
 from reflect.components.transformer_world_model.world_model import WorldModel
-from reflect.components.transformer_world_model.world_model_actor import EncoderActor
+from reflect.components.transformer_world_model.world_model_actor import (
+    EncoderActor,
+    TransformerWorldModelActor,
+    ObservationActor,
+)
+from reflect.components.models.actor import Actor
 
-from dataclasses import asdict
 import torch
-import pytest
 
 
 def test_state_world_model_imagine_rollout(
@@ -19,4 +22,68 @@ def test_state_world_model_imagine_rollout(
     o = torch.zeros((1, 1, 27))
     a_pred = actor(o)
     assert a_pred.shape == (1, 1, 8)
-    
+
+
+def test_transformer_world_model_actor_uses_world_model_encoder(
+        state_encoder,
+        state_decoder,
+        dynamic_model_8d_action,
+        actor
+    ):
+    wm = WorldModel(
+        encoder=state_encoder,
+        decoder=state_decoder,
+        dynamic_model=dynamic_model_8d_action,
+    )
+    wrapped_actor = TransformerWorldModelActor(
+        world_model=wm,
+        actor=actor,
+    )
+    o = torch.zeros((1, 27))
+    a_pred = wrapped_actor(o)
+    assert a_pred.shape == (1, 1, 8)
+
+
+def test_observation_actor_for_vector_observations(actor):
+    vector_actor = Actor(
+        input_dim=27,
+        output_dim=8,
+        bound=1,
+        num_layers=2,
+        hidden_dim=64,
+    )
+    wrapped_actor = ObservationActor(actor=vector_actor)
+    o = torch.zeros((1, 27))
+    a_pred = wrapped_actor(o)
+    assert a_pred.shape == (1, 8)
+
+
+def test_observation_actor_for_image_observations_with_flatten():
+    image_actor = Actor(
+        input_dim=3 * 8 * 8,
+        output_dim=8,
+        bound=1,
+        num_layers=2,
+        hidden_dim=64,
+    )
+    wrapped_actor = ObservationActor(
+        actor=image_actor,
+        flatten_observation=True,
+    )
+    o = torch.zeros((1, 3, 8, 8))
+    a_pred = wrapped_actor(o)
+    assert a_pred.shape == (1, 8)
+
+
+def test_observation_actor_batch_time_vector_observations():
+    vector_actor = Actor(
+        input_dim=27,
+        output_dim=8,
+        bound=1,
+        num_layers=2,
+        hidden_dim=64,
+    )
+    wrapped_actor = ObservationActor(actor=vector_actor)
+    o = torch.zeros((2, 1, 27))
+    a_pred = wrapped_actor(o)
+    assert a_pred.shape == (2, 1, 8)

--- a/src/reflect/components/transformer_world_model/world_model.py
+++ b/src/reflect/components/transformer_world_model/world_model.py
@@ -225,6 +225,7 @@ class WorldModel(Base):
             use_kv_cache: bool=True,
             with_entropies: bool=False,
             disable_gradients: bool=False,
+            actor_in_latent_space: bool=True,
         ):
         if use_kv_cache:
             return self._imagine_rollout_kvcache(
@@ -234,6 +235,7 @@ class WorldModel(Base):
                 with_observations=with_observations,
                 with_entropies=with_entropies,
                 disable_gradients=disable_gradients,
+                actor_in_latent_space=actor_in_latent_space,
             )
         else:
             return self._imagine_rollout(
@@ -241,7 +243,22 @@ class WorldModel(Base):
                 actor=actor,
                 num_timesteps=num_timesteps,
                 with_observations=with_observations,
+                actor_in_latent_space=actor_in_latent_space,
             )
+
+    def _extract_actor_input_from_latent(
+            self,
+            z_last: torch.Tensor,
+            actor_in_latent_space: bool,
+        ) -> torch.Tensor:
+        if actor_in_latent_space:
+            return z_last.detach()
+
+        o_last = self.decode(z_last).detach()
+        if o_last.dim() > 2:
+            # Default actor is MLP-based and expects vector inputs.
+            o_last = o_last.reshape(o_last.shape[0], -1)
+        return o_last
 
     def _imagine_rollout_kvcache(
             self,
@@ -254,14 +271,25 @@ class WorldModel(Base):
             with_observations: bool=False,
             with_entropies: bool=False,
             disable_gradients: bool=False,
+            actor_in_latent_space: bool=True,
         ):
 
         with torch.set_grad_enabled(not disable_gradients):    
             with FreezeParameters([self.dynamic_model, self.decoder]):
+                observations = []
+                if with_observations:
+                    b, t, *_ = z.shape
+                    o = self.decode(z.reshape(b*t, -1))
+                    observations.append(o.reshape(b, t, *o.shape[1:]))
+
                 if with_entropies:
                     entropies = []  # Use a list to collect entropies
                     # Calculate entropy for initial state
-                    action_dist = actor(z[:, -1, :].detach(), deterministic=False)
+                    actor_input = self._extract_actor_input_from_latent(
+                        z[:, -1, :],
+                        actor_in_latent_space=actor_in_latent_space
+                    )
+                    action_dist = actor(actor_input, deterministic=False)
                     entropies.append(action_dist.entropy()[:, None])
 
                 kv_cache = None
@@ -271,18 +299,19 @@ class WorldModel(Base):
                             z=z, a=a, r=r, d=d,
                             kv_cache=kv_cache
                         )
+                    if with_observations:
+                        observations.append(self.decode(z[:, -1, :])[:, None, ...])
+
+                    actor_input = self._extract_actor_input_from_latent(
+                        z[:, -1, :],
+                        actor_in_latent_space=actor_in_latent_space
+                    )
                     if with_entropies:
-                        action_dist = actor(
-                            z[:, -1, :].detach(),
-                            deterministic=False
-                        )
+                        action_dist = actor(actor_input, deterministic=False)
                         action = action_dist.rsample()
                         entropies.append(action_dist.entropy()[:, None])
                     else:
-                        action = actor(
-                            z[:, -1, :].detach(),
-                            deterministic=True
-                        )
+                        action = actor(actor_input, deterministic=True)
                     if self.environment_action_bound is not None:
                         action = torch.clamp(
                             action,
@@ -297,10 +326,7 @@ class WorldModel(Base):
                     entropy = torch.stack(entropies, dim=1)  # [batch, time, 1]
                     to_return.append(entropy)
                 if with_observations:
-                    b, t, *_ = z.shape
-                    o = self.decode(z.reshape(b*t, -1))
-                    o = o.reshape(b, t, *o.shape[1:])
-                    to_return.append(o)
+                    to_return.append(torch.cat(observations, dim=1))
                 return to_return
 
     def _imagine_rollout(
@@ -312,10 +338,17 @@ class WorldModel(Base):
             actor: Actor,
             num_timesteps: int=25,
             with_observations: bool=False,
+            actor_in_latent_space: bool=True,
         ):
 
         with torch.no_grad():    
             with FreezeParameters([self.dynamic_model, self.decoder, actor]):
+                observations = []
+                if with_observations:
+                    b, t, *_ = z.shape
+                    o = self.decode(z.reshape(b*t, -1))
+                    observations.append(o.reshape(b, t, *o.shape[1:]))
+
                 for i in range(num_timesteps):
                     z, r, d, kv_cache = self \
                         .dynamic_model.step(
@@ -323,8 +356,15 @@ class WorldModel(Base):
                             kv_cache=None,
                             use_kv_cache=False,
                         )
+                    if with_observations:
+                        observations.append(self.decode(z[:, -1, :])[:, None, ...])
+
+                    actor_input = self._extract_actor_input_from_latent(
+                        z[:, -1, :],
+                        actor_in_latent_space=actor_in_latent_space
+                    )
                     action_dist = actor(
-                        z[:, -1, :].detach(),
+                        actor_input,
                         deterministic=False
                     )
                     action = action_dist.sample()
@@ -337,8 +377,5 @@ class WorldModel(Base):
                     a = torch.cat((a, action[:, None, :]), dim=1)
                 to_return = [z, a, r, d]
                 if with_observations:
-                    b, t, *_ = z.shape
-                    o = self.decode(z.reshape(b*t, -1))
-                    o = o.reshape(b, t, *o.shape[1:])
-                    to_return.append(o)
+                    to_return.append(torch.cat(observations, dim=1))
                 return to_return

--- a/src/reflect/components/transformer_world_model/world_model.py
+++ b/src/reflect/components/transformer_world_model/world_model.py
@@ -246,15 +246,16 @@ class WorldModel(Base):
                 actor_in_latent_space=actor_in_latent_space,
             )
 
-    def _extract_actor_input_from_latent(
+    def _extract_actor_input(
             self,
             z_last: torch.Tensor,
+            o_last: torch.Tensor,
             actor_in_latent_space: bool,
         ) -> torch.Tensor:
         if actor_in_latent_space:
             return z_last.detach()
 
-        o_last = self.decode(z_last).detach()
+        o_last = o_last.detach()
         if o_last.dim() > 2:
             # Default actor is MLP-based and expects vector inputs.
             o_last = o_last.reshape(o_last.shape[0], -1)
@@ -276,17 +277,16 @@ class WorldModel(Base):
 
         with torch.set_grad_enabled(not disable_gradients):    
             with FreezeParameters([self.dynamic_model, self.decoder]):
-                observations = []
-                if with_observations:
-                    b, t, *_ = z.shape
-                    o = self.decode(z.reshape(b*t, -1))
-                    observations.append(o.reshape(b, t, *o.shape[1:]))
+                b, t, *_ = z.shape
+                o = self.decode(z.reshape(b*t, -1))
+                observations = [o.reshape(b, t, *o.shape[1:])]
 
                 if with_entropies:
                     entropies = []  # Use a list to collect entropies
                     # Calculate entropy for initial state
-                    actor_input = self._extract_actor_input_from_latent(
+                    actor_input = self._extract_actor_input(
                         z[:, -1, :],
+                        observations[0][:, -1, ...],
                         actor_in_latent_space=actor_in_latent_space
                     )
                     action_dist = actor(actor_input, deterministic=False)
@@ -299,11 +299,12 @@ class WorldModel(Base):
                             z=z, a=a, r=r, d=d,
                             kv_cache=kv_cache
                         )
-                    if with_observations:
-                        observations.append(self.decode(z[:, -1, :])[:, None, ...])
+                    o_last = self.decode(z[:, -1, :])
+                    observations.append(o_last[:, None, ...])
 
-                    actor_input = self._extract_actor_input_from_latent(
+                    actor_input = self._extract_actor_input(
                         z[:, -1, :],
+                        o_last,
                         actor_in_latent_space=actor_in_latent_space
                     )
                     if with_entropies:
@@ -343,11 +344,9 @@ class WorldModel(Base):
 
         with torch.no_grad():    
             with FreezeParameters([self.dynamic_model, self.decoder, actor]):
-                observations = []
-                if with_observations:
-                    b, t, *_ = z.shape
-                    o = self.decode(z.reshape(b*t, -1))
-                    observations.append(o.reshape(b, t, *o.shape[1:]))
+                b, t, *_ = z.shape
+                o = self.decode(z.reshape(b*t, -1))
+                observations = [o.reshape(b, t, *o.shape[1:])]
 
                 for i in range(num_timesteps):
                     z, r, d, kv_cache = self \
@@ -356,11 +355,12 @@ class WorldModel(Base):
                             kv_cache=None,
                             use_kv_cache=False,
                         )
-                    if with_observations:
-                        observations.append(self.decode(z[:, -1, :])[:, None, ...])
+                    o_last = self.decode(z[:, -1, :])
+                    observations.append(o_last[:, None, ...])
 
-                    actor_input = self._extract_actor_input_from_latent(
+                    actor_input = self._extract_actor_input(
                         z[:, -1, :],
+                        o_last,
                         actor_in_latent_space=actor_in_latent_space
                     )
                     action_dist = actor(

--- a/src/reflect/components/transformer_world_model/world_model_actor.py
+++ b/src/reflect/components/transformer_world_model/world_model_actor.py
@@ -9,6 +9,11 @@ from reflect.components.transformer_world_model.world_model import WorldModel
 from reflect.utils import FreezeParameters
 from reflect.utils import create_z_dist
 
+
+def _module_device(module: torch.nn.Module) -> torch.device:
+    return next(module.parameters()).device
+
+
 class EncoderActor(torch.nn.Module):
     def __init__(
             self,
@@ -23,6 +28,13 @@ class EncoderActor(torch.nn.Module):
         self.actor_copy = copy.deepcopy(actor)
         self.num_latent = num_latent
         self.num_cat = num_cat
+        self._sync_actor_copy_device()
+
+    def _sync_actor_copy_device(self):
+        actor_device = _module_device(self.actor)
+        actor_copy_device = _module_device(self.actor_copy)
+        if actor_copy_device != actor_device:
+            self.actor_copy = self.actor_copy.to(actor_device)
 
     def perturb_actor(self, weight_perturbation_size: float = 0.01):
         self.reset_to_original_actor()
@@ -35,23 +47,27 @@ class EncoderActor(torch.nn.Module):
 
     def reset_to_original_actor(self):
         self.actor_copy = copy.deepcopy(self.actor)
+        self._sync_actor_copy_device()
 
     def __call__(self, obs: torch.Tensor) -> torch.Tensor:
         """
         s_{t} = encoder(o_{t})
         a_{t} = actor(s_{t})
         """
-        device = next(self.actor.parameters()).device
-        if obs.dim() == 4:
+        encoder_device = _module_device(self.encoder)
+        actor_device = _module_device(self.actor)
+        if obs.dim() == 4 or obs.dim() == 2:
             obs = obs.unsqueeze(1)
-        obs = obs.to(device)
+        obs = obs.to(encoder_device)
+        self._sync_actor_copy_device()
 
         with FreezeParameters([self.encoder, self.actor, self.actor_copy]):
             z = self.encoder(obs)
             z_logits = z.reshape(-1, self.num_latent, self.num_cat)
             z_dist = create_z_dist(z_logits)
             z_sample = z_dist.rsample()
-            z_sample = z_sample.reshape(1, 1, -1)
+            z_sample = z_sample.reshape(obs.shape[0], obs.shape[1], -1)
+            z_sample = z_sample.to(actor_device)
             return self.actor_copy(z_sample, deterministic=True)
 
 
@@ -64,6 +80,13 @@ class TransformerWorldModelActor:
         self.world_model = world_model
         self.actor = actor
         self.actor_copy = copy.deepcopy(actor)
+        self._sync_actor_copy_device()
+
+    def _sync_actor_copy_device(self):
+        actor_device = _module_device(self.actor)
+        actor_copy_device = _module_device(self.actor_copy)
+        if actor_copy_device != actor_device:
+            self.actor_copy = self.actor_copy.to(actor_device)
 
     def perturb_actor(self, weight_perturbation_size: float = 0.01):
         self.reset_to_original_actor()
@@ -76,19 +99,76 @@ class TransformerWorldModelActor:
 
     def reset_to_original_actor(self):
         self.actor_copy = copy.deepcopy(self.actor)
+        self._sync_actor_copy_device()
 
     def __call__(self, obs: torch.Tensor) -> torch.Tensor:
         """
         s_{t} = encoder(o_{t})
         a_{t} = actor(s_{t})
         """
-        device = next(self.actor.parameters()).device
-        if obs.dim() == 4:
+        world_model_device = _module_device(self.world_model)
+        actor_device = _module_device(self.actor)
+        if obs.dim() == 4 or obs.dim() == 2:
             obs = obs.unsqueeze(1)
-        obs = obs.to(device)
+        obs = obs.to(world_model_device)
+        self._sync_actor_copy_device()
 
         with FreezeParameters([self.world_model, self.actor, self.actor_copy]):
             z, _ = self.world_model.encode(obs)
-            z = z.reshape(1, 1, -1)
+            z = z.reshape(obs.shape[0], obs.shape[1], -1)
+            z = z.to(actor_device)
             return self.actor_copy(z, deterministic=True)
-            
+
+
+class ObservationActor:
+    def __init__(
+            self,
+            actor: Actor,
+            flatten_observation: bool = False,
+        ):
+        self.actor = actor
+        self.actor_copy = copy.deepcopy(actor)
+        self.flatten_observation = flatten_observation
+        self._sync_actor_copy_device()
+
+    def _sync_actor_copy_device(self):
+        actor_device = _module_device(self.actor)
+        actor_copy_device = _module_device(self.actor_copy)
+        if actor_copy_device != actor_device:
+            self.actor_copy = self.actor_copy.to(actor_device)
+
+    def perturb_actor(self, weight_perturbation_size: float = 0.01):
+        self.reset_to_original_actor()
+        for param_name, param in self.actor_copy.named_parameters():
+            if "weight" in param_name:
+                param.data = param.data + torch.randn_like(param.data) * weight_perturbation_size
+
+    def reset(self):
+        pass
+
+    def reset_to_original_actor(self):
+        self.actor_copy = copy.deepcopy(self.actor)
+        self._sync_actor_copy_device()
+
+    def __call__(self, obs: torch.Tensor) -> torch.Tensor:
+        actor_device = _module_device(self.actor)
+        if obs.dim() == 1 or obs.dim() == 3:
+            obs = obs.unsqueeze(0)
+        obs = obs.to(actor_device)
+        if self.flatten_observation and obs.dim() >= 4:
+            if obs.dim() == 4:
+                obs = obs.reshape(obs.shape[0], -1)
+            else:
+                obs = obs.reshape(obs.shape[0], obs.shape[1], -1)
+        self._sync_actor_copy_device()
+        with FreezeParameters([self.actor, self.actor_copy]):
+            return self.actor_copy(obs, deterministic=True)
+
+
+class TransformerObservationActor(ObservationActor):
+    """Backward-compatible alias for a transformer policy wrapper.
+
+    This wrapper bypasses world-model encoding and feeds observations directly
+    into the actor.
+    """
+    pass

--- a/src/reflect/components/transformer_world_model/world_model_actor.py
+++ b/src/reflect/components/transformer_world_model/world_model_actor.py
@@ -152,7 +152,10 @@ class ObservationActor:
 
     def __call__(self, obs: torch.Tensor) -> torch.Tensor:
         actor_device = _module_device(self.actor)
-        if obs.dim() == 1 or obs.dim() == 3:
+        if obs.dim() == 1:
+            obs = obs.unsqueeze(0)
+        elif obs.dim() == 3 and self.flatten_observation:
+            # Treat CHW tensors as a single observation when flattening.
             obs = obs.unsqueeze(0)
         obs = obs.to(actor_device)
         if self.flatten_observation and obs.dim() >= 4:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an `actor_in_latent_space` flag to transformer `WorldModel.imagine_rollout` and route both kv-cache and non-kv-cache imagine paths through it
- support actor action selection from either latent states (`z`) or reconstructed observations (`decode(z)`)
- decode rollout states per-step and reuse the decoded tensor for actor input to avoid duplicate decode work
- keep `with_observations` for backwards compatibility, using it only to decide whether accumulated decoded observations are returned
- add an observation-driven transformer actor wrapper (`ObservationActor` + `TransformerObservationActor` alias) that bypasses world-model encoding and stays compatible with `EnvDataLoader` policy hooks
- improve actor wrapper device management by syncing `actor_copy` device with `actor` and handling encoder/world-model device transfers explicitly
- fix direct-observation wrapper shape handling for batch-time vector observations
- add focused tests for world-model actor wrapper behavior and direct-observation actor wrapper (vector, image flatten, and batch-time vector inputs)

## Testing
- `source venv/bin/activate && pytest src/reflect/components/transformer_world_model/tests/test_transformer_world_model_actor.py`
- `source venv/bin/activate && pytest src/reflect/components/transformer_world_model/tests/test_transformer_world_model.py -k "actor_input_space_selection or world_model_imagine_rollout_non_deterministic or world_model_imagine_rollout_no_kvcache"`
- `source venv/bin/activate && pytest src/reflect/data/tests/test_data_loader.py -k weight_perturbation`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-971bcf68-665c-4ff5-82a2-8822c32db2f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-971bcf68-665c-4ff5-82a2-8822c32db2f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


TODO:
 
- [x] [test-valuegrad-in-recon-states](https://colab.research.google.com/drive/11KtzUqgRHBh2iY2SbNj8j1m5iZ57gcwN?authuser=2) - ValueGrad trainer in reconstructed space
- [x] [damp-oil-nasty](https://colab.research.google.com/drive/1bueg9QKNbGqyWgbEUXNazI3MyIDs_WQT?authuser=2#scrollTo=mT-lQUAEgToZ) - PPO in reconstructed space.
- [x] Regression test ...